### PR TITLE
Update to translations for damage profiles

### DIFF
--- a/eos/saveddata/damagePattern.py
+++ b/eos/saveddata/damagePattern.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import reconstructor
 
 import eos.db
 
-_t = wx.GetTranslation
+_t = lambda x: x
 
 # Order is significant here - UI uses order as-is for built-in patterns
 BUILTINS = OrderedDict([
@@ -339,6 +339,10 @@ class DamagePattern:
                 return categories, remainingName[1:]
             categories.append(remainingName[start + 1:end])
             remainingName = remainingName[end + 1:].strip()
+
+    @property
+    def isBuiltin(self):
+        return self.ID < 0
 
     def __deepcopy__(self, memo):
         p = DamagePattern(self.emAmount, self.thermalAmount, self.kineticAmount, self.explosiveAmount)

--- a/gui/builtinContextMenus/damagePatternChange.py
+++ b/gui/builtinContextMenus/damagePatternChange.py
@@ -11,6 +11,8 @@ from gui.utils.sorter import smartSort
 from service.damagePattern import DamagePattern as DmgPatternSvc
 from service.fit import Fit
 
+_t = wx.GetTranslation
+
 
 class ChangeDamagePattern(ContextMenuUnconditional):
 
@@ -43,8 +45,10 @@ class ChangeDamagePattern(ContextMenuUnconditional):
         for pattern in self.patterns:
             container = self.items
             for categoryName in pattern.hierarchy:
+                categoryName = _t('[' + categoryName + ']')[1:-1] if pattern.isBuiltin else categoryName
                 container = container[1].setdefault(categoryName, (OrderedDict(), OrderedDict()))
-            container[0][pattern.shortName] = pattern
+            shortName = _t(pattern.shortName) if pattern.isBuiltin else pattern.shortName
+            container[0][shortName] = pattern
 
         return list(self.items[0].keys()) + list(self.items[1].keys())
 


### PR DESCRIPTION
A few things:
* I replace the `wx` requirements with `_t = lambda x: x`. This allows `gettext` to find and extract these strings without it actually doing anything
* To actually do the translations, we fudge the menu creation when we're dealing with a built in pattern
* Didn't touch target resists, those would have to be converted the same way

One caveat: because of the way the translations are set up, I had to screw around with the category names:

`categoryName = _t('[' + categoryName + ']')[1:-1] if pattern.isBuiltin else categoryName`

This is translating `[text]`, but then we don't want the brackets in the final output (I also didn't realize until this point that the parsing of the strings is done in the eos class). The works (and should work well) but is a bit jank.

What I would recommend, but want your thoughts on:

```
_t = lambda x: x  # translatable string
_c = lambda x: "[{}]".format(x)  # category

BUILTINS = OrderedDict([
    (-1, (_t('Uniform'), 25, 25, 25, 25)),
    (-2, (_c(_t('Generic')) + _t('EM'), 1, 0, 0, 0)),
    (-3, (_c(_t('Generic')) + _t('Thermal'), 0, 1, 0, 0)),
    (-4, (_c(_t('Generic')) + _t('Kinetic'), 0, 0, 1, 0)),
    (-5, (_c(_t('Generic')) + _t('Explosive'), 0, 0, 0, 1)),
...
```

`_c()` would be a function that adds the `[]`. This basically allows us to translate just the text without all the concatenation that would come with either of these options: `'['+_t('Generic')+']'` or `'[{}]'.format(_t('Generic'))`. I think the `_c()` function is cleaner. And then on the GUI side, the class already gives us the literal category and short name, so should be easy peasy

 